### PR TITLE
add support for hidpi rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Optionally you can tweak the behavior and appearance by initializing it with som
 | dropRadius | float | 20 | The size (in pixels) of the drop that results by clicking or moving the mouse over the canvas. |
 | perturbance | float | 0.03 | Basically the amount of refraction caused by a ripple. 0 means there is no refraction. |
 | resolution | integer | 256 | The width and height of the WebGL texture to render to. The larger this value, the smoother the rendering and the slower the ripples will propagate. |
+| pixelRatio | float | devicePixelRatio | Scale of the canvas rendering. When not set, it defaults to the value of window.devicePixelRatio. Set to 1 if experiencing performance issues. |
 | interactive | bool | true | Whether mouse clicks and mouse movement triggers the effect. |
 | crossOrigin | string | "" | The crossOrigin attribute to use for the affected image. For more information see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes).
 

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -2,6 +2,7 @@ import type { Callback, IRipples } from "./types";
 
 export class Options {
   resolution: number;
+  pixelRatio: number;
   dropRadius: number;
   perturbance: number;
   crossOrigin: string;
@@ -13,6 +14,7 @@ export class Options {
     this.imageUrl = configuration.imageUrl;
     this.dropRadius = configuration.dropRadius;
     this.resolution = configuration.resolution;
+    this.pixelRatio = configuration.pixelRatio;
     this.interactive = configuration.interactive;
     this.perturbance = configuration.perturbance;
     this.crossOrigin = configuration.crossOrigin;
@@ -22,6 +24,7 @@ export class Options {
   public static defaults = {
     imageUrl: null,
     resolution: 256,
+    pixelRatio: window.devicePixelRatio || 1,
     dropRadius: 20,
     perturbance: 0.03,
     interactive: true,

--- a/src/Ripples.ts
+++ b/src/Ripples.ts
@@ -37,11 +37,13 @@ export class Ripples extends WebGL {
   public updateSize() {
     const { offsetHeight, offsetWidth } = this.target;
     if (
-      offsetWidth !== this.canvas.width ||
-      offsetHeight !== this.canvas.height
+      offsetWidth * this.pixelRatio !== this.canvas.width ||
+      offsetHeight * this.pixelRatio !== this.canvas.height
     ) {
-      this.canvas.width = offsetWidth;
-      this.canvas.height = offsetHeight;
+      this.canvas.width = offsetWidth * this.pixelRatio;
+      this.canvas.height = offsetHeight * this.pixelRatio;
+      this.canvas.style.width = `${offsetWidth}px`;
+      this.canvas.style.height = `${offsetHeight}px`;
       void this.reloadImage();
     }
   }

--- a/src/WebGL.ts
+++ b/src/WebGL.ts
@@ -84,8 +84,10 @@ export class WebGL extends Options {
   }
 
   private positionCanvas() {
-    this.canvas.width = this.target.offsetWidth;
-    this.canvas.height = this.target.offsetHeight;
+    this.canvas.width = this.target.offsetWidth * this.pixelRatio;
+    this.canvas.height = this.target.offsetHeight * this.pixelRatio;
+    this.canvas.style.width = `${this.target.offsetWidth}px`;
+    this.canvas.style.height = `${this.target.offsetHeight}px`;
     this.canvas.style.position = "absolute";
     this.canvas.style.top = "0";
     this.canvas.style.right = "0";

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface BrowserConfig {
 export interface IRipples {
   imageUrl: null | string;
   resolution: number;
+  pixelRatio: number;
   dropRadius: number;
   perturbance: number;
   interactive: boolean;


### PR DESCRIPTION
Congrats @alexfigliolia on this great rewrite!

I added support for HiDPI / retina screens via a new `pixelRatio` option which scales the canvas to avoid blurriness.